### PR TITLE
Sb/build local cache

### DIFF
--- a/getDataFRF.py
+++ b/getDataFRF.py
@@ -95,7 +95,8 @@ def getnc(dataLoc, callingClass, epoch1=0, epoch2=0, dtRound=60, cutrange=100000
     if callingClass == 'getDataTestBed':  # overwrite pName if calling for model data
         pName = u'cmtb'
 
-    assert os.system("ping -c 1 " + THREDDSloc) == 0, f"Not able to see {THREDDSloc)
+    if os.system("ping -c 1 " + THREDDSloc) ~= 0:
+        return ConnectionError(f"Not able to see {THREDDSloc))
     
     # now set URL for netCDF file call,
     if start is None and end is None:

--- a/getDataFRF.py
+++ b/getDataFRF.py
@@ -95,9 +95,9 @@ def getnc(dataLoc, callingClass, epoch1=0, epoch2=0, dtRound=60, cutrange=100000
     if callingClass == 'getDataTestBed':  # overwrite pName if calling for model data
         pName = u'cmtb'
 
-    if os.system("ping -c 1 " + THREDDSloc) != 0:
-        return ConnectionError(f"Not able to see {THREDDSloc}")
-    
+    # if os.system("ping -c 1 " + THREDDSloc) != 0:
+    #     return ConnectionError(f"Not able to see {THREDDSloc}")
+    #
     # now set URL for netCDF file call,
     if start is None and end is None:
         ncfileURL = urljoin('[FillMismatch]'+THREDDSloc, pName, dataLoc)
@@ -774,9 +774,11 @@ class getObs:
         self.WLdataindex = gettime(allEpoch=self.allEpoch, epochStart=self.epochd1,
                                    epochEnd=self.epochd2)
         
-        if np.size(self.WLdataindex) > 1:
+        if np.size(self.WLdataindex) >= 1 and (self.WLdataindex != None):
             self.WLtime = nc.num2date(self.allEpoch[self.WLdataindex], self.ncfile['time'].units,
                                       only_use_cftime_datetimes=False)
+            #  for singular WLtime indices, might need to increas the dimension so it makes the below lists/arrays of
+            #  size one, to keep downstream compatibility
             self.WLpacket = {
                 'name':        str(self.ncfile.title),
                 'WL':          self.ncfile['waterLevel'][self.WLdataindex],
@@ -789,8 +791,8 @@ class getObs:
                     }
             # this is faster to calculate myself, than pull from server
             self.WLpacket['residual'] = self.WLpacket['WL'] - self.WLpacket['predictedWL']
-        elif self.WLdataindex is not None and np.size(self.WLdataindex) == 1:
-            raise BaseException('you have 1 WL point, can the above be a >= logic or does 1 cause problems')
+        # elif self.WLdataindex is not None and np.size(self.WLdataindex) == 1:
+        #     raise BaseException('you have 1 WL point, can the above be a >= logic or does 1 cause problems')
         else:
             print('ERROR: there is no WATER level Data for this time period!!!')
             self.WLpacket = None

--- a/getDataFRF.py
+++ b/getDataFRF.py
@@ -2129,6 +2129,8 @@ class getObs:
                 'lat':       self.ncfile['latitude'][ys, xs],
                 'lon':       self.ncfile['longitude'][ys,xs]
                 }
+        DEMdata['elevation_mean'] = np.nanmean(DEMdata['elevation'], axis=0)
+        DEMdata['elevation_var'] = np.nanvar(DEMdata['elevation'], axis=0)
         return DEMdata
     
     def getBathyRegionalDEM(self, utmEmin, utmEmax, utmNmin, utmNmax):

--- a/getDataFRF.py
+++ b/getDataFRF.py
@@ -932,7 +932,7 @@ class getObs:
         elif len(dataReturns) == 2:
             self.ncfile = dataReturns[0]
             self.allEpoch = dataReturns[1]
-            indexRef=[0]
+            indexRef=[0, len(self.ncfile['time'][:])]
         elif len(dataReturns) == 3:
             self.ncfile = dataReturns[0]
             self.allEpoch = dataReturns[1]

--- a/getDataFRF.py
+++ b/getDataFRF.py
@@ -48,7 +48,7 @@ def gettime(allEpoch, epochStart, epochEnd, indexRef=0):
     finally:
         return idx
 
-def getnc(dataLoc, callingClass, epoch1=0, epoch2=0, dtRound=60, cutrange=100000,**kwargs):
+def getnc(dataLoc, callingClass, epoch1=0, epoch2=0, dtRound=60, cutrange=100000, **kwargs):
     """Function grabs the netCDF file interested.
     
     Responsible for drilling down to specific monthly file if applicable to speed things up.
@@ -95,6 +95,8 @@ def getnc(dataLoc, callingClass, epoch1=0, epoch2=0, dtRound=60, cutrange=100000
     if callingClass == 'getDataTestBed':  # overwrite pName if calling for model data
         pName = u'cmtb'
 
+    assert os.system("ping -c 1 " + THREDDSloc) == 0, f"Not able to see {THREDDSloc)
+    
     # now set URL for netCDF file call,
     if start is None and end is None:
         ncfileURL = urljoin('[FillMismatch]'+THREDDSloc, pName, dataLoc)
@@ -245,7 +247,7 @@ class getObs:
         self._comp_time()
         assert type(self.d2) == DT.datetime, 'd1 need to be in python "Datetime" data types'
         assert type(self.d1) == DT.datetime, 'd2 need to be in python "Datetime" data types'
-    
+
     def _comp_time(self):
         """Test if times are backwards."""
         assert self.d2 >= self.d1, 'finish time: end needs to be after start time: start'

--- a/getDataFRF.py
+++ b/getDataFRF.py
@@ -774,7 +774,7 @@ class getObs:
         self.WLdataindex = gettime(allEpoch=self.allEpoch, epochStart=self.epochd1,
                                    epochEnd=self.epochd2)
         
-        if np.size(self.WLdataindex) >= 1 and (self.WLdataindex != None):
+        if np.size(self.WLdataindex) >= 1 and (self.WLdataindex is not None):
             self.WLtime = nc.num2date(self.allEpoch[self.WLdataindex], self.ncfile['time'].units,
                                       only_use_cftime_datetimes=False)
             #  for singular WLtime indices, might need to increas the dimension so it makes the below lists/arrays of


### PR DESCRIPTION
this ties to Issue SBFRF/murgTools#9.  Need to build a local cache when downloading data.  inital approach will be to build a local copy of the TDS server.  This will require downloading netCDF files and creating a folder structure to mimic that of the TDS server (at a specified `userDefined` location, then with each new querey, grabbing those files, and populating the folder structure.  if some variable (say `pullFromLocalCache` is marked `True` on initialization, then the qurery can then just update the TDS file path to the local path directory (instead of the URL), and output should otherwise remain the same

-  At some point, logic will have to be rolled in to check the modified data and update the local copy.  This will not be included in this PR. 
- it will build off of the server check

@thesser1  what do you think about this logic and approach?